### PR TITLE
Remove duplicate type definition

### DIFF
--- a/src/@types/lists/anime.ts
+++ b/src/@types/lists/anime.ts
@@ -60,7 +60,3 @@ interface MediaListCollection {
 export interface AnimeListResponse {
   MediaListCollection: MediaListCollection;
 }
-
-interface MediaListCollection {
-  lists: List[];
-}


### PR DESCRIPTION
There is a duplicate definition for `MediaListCollection` in the `lists/anime.ts` types file. This pull request removes the redundant definition.