### PR TITLE
Fix Mutation param, anime/manga list, updateMedia and currentUser typings

### DIFF
--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -88,8 +88,8 @@ export const ShowMutationsTypes = {
   hiddenFromStatusLists: 'Boolean',
   customLists: '[String]',
   advancedScores: '[Float]',
-  startedAt: 'FuzzyDate',
-  completedAt: 'FuzzyDate',
+  startedAt: 'FuzzyDateInput',
+  completedAt: 'FuzzyDateInput',
 };
 
 export interface Reply {

--- a/src/queries/lists.ts
+++ b/src/queries/lists.ts
@@ -99,7 +99,7 @@ export class Lists extends BaseQuery {
     }
   }`;
 
-    return await this.api.get<AnimeListResponse>(query, queryVals[0]);
+    return await this.api.get<{ data: AnimeListResponse }>(query, queryVals[0]).then((r) => r.data);
   };
 
   manga = async (idOrUsername: string, status: MediaListStatus): Promise<MangaListResponse> => {
@@ -186,6 +186,6 @@ export class Lists extends BaseQuery {
     }
   }`;
 
-    return await this.api.get<MangaListResponse>(query, queryVals[0]);
+    return await this.api.get<{ data: MangaListResponse }>(query, queryVals[0]).then((r) => r.data);
   };
 }

--- a/src/queries/user.ts
+++ b/src/queries/user.ts
@@ -11,7 +11,7 @@ export class User extends BaseQuery {
   getCurrentUser = async (): Promise<UserProfile> => {
     if (!this.access_token) throw new NotLoggedInException();
 
-    return await this.api.get<UserProfile>(`query{Viewer{${UserProfileQuery}}}`);
+    return await this.api.get<{ data: { Viewer: UserProfile } }>(`query{Viewer{${UserProfileQuery}}}`).then((r) => r.data.Viewer);
   };
 
   getMediaIdByAnilistID = async (anilistId: number): Promise<number | undefined> => {
@@ -70,7 +70,7 @@ export class User extends BaseQuery {
                         }
                     }`;
 
-    return await this.api.get<{ SaveMediaListEntry: ShowMutations }>(query, variables);
+    return await this.api.get<{ data: { SaveMediaListEntry: ShowMutations } }>(query, variables).then((r) => r.data);
   };
 
   deleteShow = async (anilistId: number): Promise<{ DeleteMediaListEntry: { deleted: boolean } }> => {


### PR DESCRIPTION
- Mapped the returned responses of `user.getCurrentUser`, `user.updateMedia`, `lists.anime` and `lists.manga` so the actual response (typically involving some form of `data` wrapper) match the expected typings. 
Fixes #3

- Changed the types of `startedAt` and `completedAt` in the SaveMediaListEntry mutation to `FuzzyDateInput`, as `FuzzyDate` is rejected by the Anilist API. 
Fixes #4