### PR TITLE
Expose the api-core client lifecycle

### DIFF
--- a/.changeset/tidy-ducks-dispose.md
+++ b/.changeset/tidy-ducks-dispose.md
@@ -1,0 +1,5 @@
+---
+"@api-wrappers/anilist-wrapper": minor
+---
+
+Expose the underlying api-core HTTP client, client bundle factory, and disposal lifecycle.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,5 +1,6 @@
 import {
-	createClient as createCoreClient,
+	type BaseHttpClient,
+	createClient as createApiCoreClient,
 	dedupeGraphQLFragmentDefinitions,
 } from "@api-wrappers/api-core";
 import { type GraphQLClient, getSdk } from "../__generated__/anilist-sdk";
@@ -7,14 +8,20 @@ import { type GraphQLClient, getSdk } from "../__generated__/anilist-sdk";
 const ANILIST_API_URL = "https://graphql.anilist.co";
 const MAX_ATTEMPTS = 4;
 
-export const createGraphQLClient = (token?: string): GraphQLClient => {
+export interface AnilistClientBundle {
+	httpClient: BaseHttpClient;
+	graphQLClient: GraphQLClient;
+	sdkClient: ReturnType<typeof getSdk>;
+}
+
+export const createHttpClient = (token?: string): BaseHttpClient => {
 	const headers: Record<string, string> = {
 		"Content-Type": "application/json",
 	};
 
 	if (token) headers.Authorization = `Bearer ${token}`;
 
-	const httpClient = createCoreClient({
+	return createApiCoreClient({
 		baseUrl: ANILIST_API_URL,
 		defaultHeaders: headers,
 		retry: {
@@ -23,8 +30,35 @@ export const createGraphQLClient = (token?: string): GraphQLClient => {
 			retriableStatusCodes: [429],
 		},
 	});
+};
 
-	const client: GraphQLClient = {
+export const createGraphQLClient = (token?: string): GraphQLClient => {
+	return createGraphQLClientFromHttpClient(createHttpClient(token));
+};
+
+export const createClientBundle = (token?: string): AnilistClientBundle => {
+	const httpClient = createHttpClient(token);
+	const graphQLClient = createGraphQLClientFromHttpClient(httpClient);
+
+	return {
+		httpClient,
+		graphQLClient,
+		sdkClient: createSdkClient(graphQLClient),
+	};
+};
+
+export const createClient = (token?: string) => {
+	return createSdkClient(createGraphQLClient(token));
+};
+
+export const createSdkClient = (client: GraphQLClient) => {
+	return getSdk(client);
+};
+
+const createGraphQLClientFromHttpClient = (
+	httpClient: Pick<BaseHttpClient, "graphql">,
+): GraphQLClient => {
+	return {
 		request({ document, variables, requestHeaders, signal }) {
 			return httpClient.graphql("", {
 				query: dedupeGraphQLFragmentDefinitions(document),
@@ -34,14 +68,4 @@ export const createGraphQLClient = (token?: string): GraphQLClient => {
 			});
 		},
 	};
-
-	return client;
-};
-
-export const createClient = (token?: string) => {
-	return createSdkClient(createGraphQLClient(token));
-};
-
-export const createSdkClient = (client: GraphQLClient) => {
-	return getSdk(client);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
+import type { BaseHttpClient } from "@api-wrappers/api-core";
 import type { ANILISTSDK } from "./@types";
 import type { GraphQLClient } from "./__generated__/anilist-sdk";
-import { createGraphQLClient, createSdkClient } from "./client";
+import { createClientBundle } from "./client";
 import { AnimeService } from "./services/animeService";
 import { CharacterService } from "./services/characterService";
 import { GraphQLService } from "./services/graphqlService";
@@ -10,21 +11,17 @@ import { MediaService } from "./services/mediaService";
 import { StaffService } from "./services/staffService";
 import { UserService } from "./services/userService";
 
-/**
- * Main class for interacting with the AniList API.
- * Provides access to various service classes for making different queries to the AniList API.
- */
+/** Main class for interacting with the AniList API. */
 class Anilist {
 	private client: ANILISTSDK;
 	private graphQLClient: GraphQLClient;
+	readonly http: BaseHttpClient;
 
-	/**
-	 * Constructs a new instance of the Anilist client.
-	 * @param token - Optional authentication token for the AniList API.
-	 */
 	constructor(token?: string) {
-		this.graphQLClient = createGraphQLClient(token);
-		this.client = createSdkClient(this.graphQLClient);
+		const { graphQLClient, httpClient, sdkClient } = createClientBundle(token);
+		this.http = httpClient;
+		this.graphQLClient = graphQLClient;
+		this.client = sdkClient;
 
 		this.anime = new AnimeService(this.client, this.graphQLClient);
 		this.character = new CharacterService(this.client, this.graphQLClient);
@@ -36,59 +33,32 @@ class Anilist {
 		this.user = new UserService(this.client, this.graphQLClient);
 	}
 
-	/**
-	 * Service class for interacting with AniList's anime-related queries.
-	 * @type {AnimeService}
-	 */
+	/** Releases resources held by api-core plugins and transports. */
+	dispose(): Promise<void> {
+		return this.http.dispose();
+	}
+
 	anime: AnimeService;
-
-	/**
-	 * Service class for interacting with AniList's character-related queries.
-	 * @type {CharacterService}
-	 */
 	character: CharacterService;
-
-	/**
-	 * Low-level GraphQL access for every AniList query and mutation.
-	 * @type {GraphQLService}
-	 */
 	graphql: GraphQLService;
-
-	/**
-	 * Service class for interacting with AniList's manga-related queries.
-	 * @type {MangaService}
-	 */
 	manga: MangaService;
-
-	/**
-	 * Service class for interacting with AniList's media-related queries.
-	 * @type {MediaService}
-	 */
 	media: MediaService;
-
-	/**
-	 * Service class for interacting with AniList's media list-related queries.
-	 * @type {MediaListService}
-	 */
 	mediaList: MediaListService;
-
-	/**
-	 * Service class for interacting with AniList's staff-related queries.
-	 * @type {StaffService}
-	 */
 	staff: StaffService;
-
-	/**
-	 * Service class for interacting with AniList's user-related queries.
-	 * @type {UserService}
-	 */
 	user: UserService;
 }
 
 export { gql } from "@api-wrappers/api-core";
 export * from "./__generated__/anilist-schema";
 export * as AniListOperations from "./__generated__/anilist-sdk";
-export { createClient, createGraphQLClient, createSdkClient } from "./client";
+export type { AnilistClientBundle } from "./client";
+export {
+	createClient,
+	createClientBundle,
+	createGraphQLClient,
+	createHttpClient,
+	createSdkClient,
+} from "./client";
 export type {
 	CharacterPageSelect,
 	CharacterSelect,

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -24,6 +24,55 @@ const coreClientConfigs: Array<CoreClientConfig> = [];
 const graphQLCalls: Array<GraphQLCall> = [];
 const graphQLResponse = { ok: true };
 
+const dedupeGraphQLFragmentDefinitions = (source: string): string => {
+	const seen = new Map<string, string>();
+	const pattern =
+		/\bfragment\s+([_A-Za-z][_0-9A-Za-z]*)\s+on\s+[_A-Za-z][_0-9A-Za-z]*/g;
+	let result = "";
+	let cursor = 0;
+	let match = pattern.exec(source);
+
+	while (match) {
+		const name = match[1];
+		const bodyStart = source.indexOf("{", pattern.lastIndex);
+		if (!name || bodyStart === -1) break;
+
+		let depth = 0;
+		let bodyEnd = -1;
+		for (let index = bodyStart; index < source.length; index++) {
+			if (source[index] === "{") depth++;
+			if (source[index] === "}") depth--;
+			if (depth === 0) {
+				bodyEnd = index;
+				break;
+			}
+		}
+		if (bodyEnd === -1) break;
+
+		const definitionEnd = bodyEnd + 1;
+		const normalized = source
+			.slice(match.index, definitionEnd)
+			.replace(/\s+/g, " ")
+			.trim();
+		const previous = seen.get(name);
+
+		if (previous === undefined) {
+			seen.set(name, normalized);
+			result += source.slice(cursor, definitionEnd);
+		} else if (previous === normalized) {
+			result += source.slice(cursor, match.index);
+		} else {
+			throw new Error(`Conflicting GraphQL fragment definition: ${name}`);
+		}
+
+		cursor = definitionEnd;
+		pattern.lastIndex = definitionEnd;
+		match = pattern.exec(source);
+	}
+
+	return result + source.slice(cursor);
+};
+
 mock.module("@api-wrappers/api-core", () => ({
 	createClient: (config: CoreClientConfig) => {
 		coreClientConfigs.push(config);
@@ -33,8 +82,11 @@ mock.module("@api-wrappers/api-core", () => ({
 				graphQLCalls.push({ path, options });
 				return graphQLResponse;
 			},
+			request: async () => graphQLResponse,
+			dispose: async () => {},
 		};
 	},
+	dedupeGraphQLFragmentDefinitions,
 	gql: (strings: TemplateStringsArray, ...values: Array<unknown>) =>
 		strings.reduce(
 			(source, segment, index) => `${source}${segment}${values[index] ?? ""}`,

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { Anilist, createClientBundle, createHttpClient } from "../src";
+
+describe("api-core lifecycle", () => {
+	it("exposes the shared HTTP client on Anilist", async () => {
+		const anilist = new Anilist();
+
+		expect(anilist.http).toBeDefined();
+		expect(typeof anilist.http.graphql).toBe("function");
+		await anilist.dispose();
+	});
+
+	it("creates one HTTP client for a complete client bundle", async () => {
+		const bundle = createClientBundle();
+
+		expect(bundle.httpClient).toBeDefined();
+		expect(bundle.graphQLClient).toBeDefined();
+		expect(bundle.sdkClient).toBeDefined();
+		await bundle.httpClient.dispose();
+	});
+
+	it("exports the lower-level HTTP client factory", async () => {
+		const client = createHttpClient();
+
+		expect(typeof client.request).toBe("function");
+		await client.dispose();
+	});
+});


### PR DESCRIPTION
## What changed

- Adds `createHttpClient` and `createClientBundle` factories.
- Ensures the generated SDK and low-level GraphQL adapter share one `BaseHttpClient` instance.
- Exposes that instance as `anilist.http`.
- Adds `anilist.dispose()` to release plugin, cache, timer, or transport resources.
- Exports the bundle type and adds deterministic lifecycle tests plus a minor Changeset.

## Why

The wrapper previously hid the api-core runtime after constructing its GraphQL adapter, so consumers could not inspect response infrastructure or dispose plugins cleanly.

## Validation

GitHub Actions will run the wrapper's formatting, typecheck, test, build, and package verification.