### PR TITLE
Reject conflicting duplicate GraphQL fragments

### DIFF
--- a/.changeset/calm-badgers-fragments.md
+++ b/.changeset/calm-badgers-fragments.md
@@ -1,0 +1,5 @@
+---
+"@api-wrappers/anilist-wrapper": patch
+---
+
+Reject conflicting duplicate GraphQL fragments instead of silently keeping the first definition.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -44,7 +44,7 @@ export const createSdkClient = (client: GraphQLClient) => {
 };
 
 const dedupeFragmentDefinitions = (source: string) => {
-	const seen = new Set<string>();
+	const seen = new Map<string, string>();
 	const fragmentPattern =
 		/\bfragment\s+([_A-Za-z][_0-9A-Za-z]*)\s+on\s+[_A-Za-z][_0-9A-Za-z]*/g;
 	let result = "";
@@ -68,12 +68,19 @@ const dedupeFragmentDefinitions = (source: string) => {
 		}
 
 		const definitionEnd = bodyEnd + 1;
+		const normalizedDefinition = source
+			.slice(match.index, definitionEnd)
+			.replace(/\s+/g, " ")
+			.trim();
+		const previousDefinition = seen.get(name);
 
-		if (seen.has(name)) {
+		if (previousDefinition === undefined) {
+			seen.set(name, normalizedDefinition);
+			result += source.slice(cursor, definitionEnd);
+		} else if (previousDefinition === normalizedDefinition) {
 			result += source.slice(cursor, match.index);
 		} else {
-			seen.add(name);
-			result += source.slice(cursor, definitionEnd);
+			throw new Error(`Conflicting GraphQL fragment definition: ${name}`);
 		}
 
 		cursor = definitionEnd;

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,4 +1,7 @@
-import { createClient as createCoreClient } from "@api-wrappers/api-core";
+import {
+	createClient as createCoreClient,
+	dedupeGraphQLFragmentDefinitions,
+} from "@api-wrappers/api-core";
 import { type GraphQLClient, getSdk } from "../__generated__/anilist-sdk";
 
 const ANILIST_API_URL = "https://graphql.anilist.co";
@@ -24,7 +27,7 @@ export const createGraphQLClient = (token?: string): GraphQLClient => {
 	const client: GraphQLClient = {
 		request({ document, variables, requestHeaders, signal }) {
 			return httpClient.graphql("", {
-				query: dedupeFragmentDefinitions(document),
+				query: dedupeGraphQLFragmentDefinitions(document),
 				variables,
 				headers: requestHeaders,
 				signal: signal ?? undefined,
@@ -41,66 +44,4 @@ export const createClient = (token?: string) => {
 
 export const createSdkClient = (client: GraphQLClient) => {
 	return getSdk(client);
-};
-
-const dedupeFragmentDefinitions = (source: string) => {
-	const seen = new Map<string, string>();
-	const fragmentPattern =
-		/\bfragment\s+([_A-Za-z][_0-9A-Za-z]*)\s+on\s+[_A-Za-z][_0-9A-Za-z]*/g;
-	let result = "";
-	let cursor = 0;
-	let match = fragmentPattern.exec(source);
-
-	while (match) {
-		const name = match[1];
-		const bodyStart = source.indexOf("{", fragmentPattern.lastIndex);
-
-		if (!name || bodyStart === -1) {
-			match = fragmentPattern.exec(source);
-			continue;
-		}
-
-		const bodyEnd = findMatchingBrace(source, bodyStart);
-
-		if (bodyEnd === -1) {
-			match = fragmentPattern.exec(source);
-			continue;
-		}
-
-		const definitionEnd = bodyEnd + 1;
-		const normalizedDefinition = source
-			.slice(match.index, definitionEnd)
-			.replace(/\s+/g, " ")
-			.trim();
-		const previousDefinition = seen.get(name);
-
-		if (previousDefinition === undefined) {
-			seen.set(name, normalizedDefinition);
-			result += source.slice(cursor, definitionEnd);
-		} else if (previousDefinition === normalizedDefinition) {
-			result += source.slice(cursor, match.index);
-		} else {
-			throw new Error(`Conflicting GraphQL fragment definition: ${name}`);
-		}
-
-		cursor = definitionEnd;
-		fragmentPattern.lastIndex = definitionEnd;
-		match = fragmentPattern.exec(source);
-	}
-
-	return result + source.slice(cursor);
-};
-
-const findMatchingBrace = (source: string, start: number) => {
-	let depth = 0;
-
-	for (let index = start; index < source.length; index++) {
-		const character = source[index];
-
-		if (character === "{") depth++;
-		if (character === "}") depth--;
-		if (depth === 0) return index;
-	}
-
-	return -1;
 };

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -77,7 +77,7 @@ describe("client transport", () => {
 		});
 	});
 
-	it("forwards request options and removes duplicate fragment definitions", async () => {
+	it("forwards request options and removes equivalent fragments", async () => {
 		const signal = new AbortController().signal;
 		const client = createGraphQLClient("token-123");
 
@@ -87,25 +87,14 @@ describe("client transport", () => {
 					Media(id: $id) {
 						...TitleFields
 						...TitleFields
-						...IdFields
 					}
 				}
 
 				fragment TitleFields on Media {
-					title {
-						romaji
-					}
+					title { romaji }
 				}
 
-				fragment TitleFields on Media {
-					title {
-						english
-					}
-				}
-
-				fragment IdFields on Media {
-					id
-				}
+				fragment TitleFields on Media { title { romaji } }
 			`,
 			variables: { id: 16498 },
 			requestHeaders: { "x-request": "test" },
@@ -126,10 +115,20 @@ describe("client transport", () => {
 			graphQLCalls[0]?.options.query.match(/fragment\s+TitleFields\s+on/g)
 				?.length,
 		).toBe(1);
-		expect(
-			graphQLCalls[0]?.options.query.match(/fragment\s+IdFields\s+on/g)?.length,
-		).toBe(1);
-		expect(graphQLCalls[0]?.options.query).toContain("romaji");
-		expect(graphQLCalls[0]?.options.query).not.toContain("english");
+	});
+
+	it("rejects conflicting fragment definitions", async () => {
+		const client = createGraphQLClient();
+
+		await expect(
+			client.request({
+				document: `
+					query Example { Media { ...TitleFields } }
+					fragment TitleFields on Media { title { romaji } }
+					fragment TitleFields on Media { title { english } }
+				`,
+			}),
+		).rejects.toThrow("Conflicting GraphQL fragment definition: TitleFields");
+		expect(graphQLCalls).toHaveLength(0);
 	});
 });

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -117,10 +117,10 @@ describe("client transport", () => {
 		).toBe(1);
 	});
 
-	it("rejects conflicting fragment definitions", async () => {
+	it("rejects conflicting fragment definitions", () => {
 		const client = createGraphQLClient();
 
-		await expect(
+		expect(() =>
 			client.request({
 				document: `
 					query Example { Media { ...TitleFields } }
@@ -128,7 +128,7 @@ describe("client transport", () => {
 					fragment TitleFields on Media { title { english } }
 				`,
 			}),
-		).rejects.toThrow("Conflicting GraphQL fragment definition: TitleFields");
+		).toThrow("Conflicting GraphQL fragment definition: TitleFields");
 		expect(graphQLCalls).toHaveLength(0);
 	});
 });


### PR DESCRIPTION
## What changed

- Deduplicates repeated fragments only when their normalized definitions are equivalent.
- Throws a clear error when one fragment name is used for different selection sets.
- Replaces the previous test that documented silently dropping the later definition.
- Adds focused equivalent/conflicting fragment coverage and a patch Changeset.

## Why

The previous name-only deduper could silently remove valid requested fields and change the resulting AniList query. Conflicts now fail before any network request is made.

## Validation

GitHub Actions will run the wrapper verification pipeline.