### PR TITLE
Expose api-core controls on raw GraphQL requests

### DIFF
--- a/.changeset/soft-apes-options.md
+++ b/.changeset/soft-apes-options.md
@@ -1,0 +1,5 @@
+---
+"@api-wrappers/anilist-wrapper": minor
+---
+
+Expose api-core timeout, cache, tag, operation-name, header, and abort controls through raw GraphQL requests.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -8,7 +8,11 @@ import {
 	type MaybePromise,
 	mergeHeaders,
 } from "@api-wrappers/api-core";
-import { type GraphQLClient, getSdk } from "../__generated__/anilist-sdk";
+import {
+	type GraphQLClient,
+	type GraphQLClientRequestOptions,
+	getSdk,
+} from "../__generated__/anilist-sdk";
 
 const ANILIST_API_URL = "https://graphql.anilist.co";
 const MAX_ATTEMPTS = 4;
@@ -27,6 +31,15 @@ export interface AnilistOptions {
 	};
 	/** Existing api-core client to use instead of constructing one. */
 	httpClient?: BaseHttpClient;
+}
+
+export interface AnilistRequestOptions {
+	requestHeaders?: Record<string, string>;
+	signal?: RequestInit["signal"];
+	timeoutMs?: number;
+	cacheKey?: string;
+	tags?: string[];
+	operationName?: string;
 }
 
 export type AnilistClientInput = string | AnilistOptions | undefined;
@@ -94,12 +107,20 @@ const createGraphQLClientFromHttpClient = (
 	httpClient: Pick<BaseHttpClient, "graphql">,
 ): GraphQLClient => {
 	return {
-		request({ document, variables, requestHeaders, signal }) {
+		request(options) {
+			const { document, variables, requestHeaders, signal } = options;
+			const requestOptions = options as GraphQLClientRequestOptions &
+				AnilistRequestOptions;
+
 			return httpClient.graphql("", {
 				query: dedupeGraphQLFragmentDefinitions(document),
 				variables,
 				headers: requestHeaders,
 				signal: signal ?? undefined,
+				timeoutMs: requestOptions.timeoutMs,
+				cacheKey: requestOptions.cacheKey,
+				tags: requestOptions.tags,
+				operationName: requestOptions.operationName,
 			});
 		},
 	};

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ export type {
 	AnilistClientBundle,
 	AnilistClientInput,
 	AnilistOptions,
+	AnilistRequestOptions,
 	AnilistToken,
 } from "./client";
 export {

--- a/src/services/graphqlService.ts
+++ b/src/services/graphqlService.ts
@@ -1,7 +1,5 @@
-import type {
-	GraphQLClient,
-	GraphQLClientRequestOptions,
-} from "../__generated__/anilist-sdk";
+import type { GraphQLClient } from "../__generated__/anilist-sdk";
+import type { AnilistRequestOptions } from "../client";
 
 /**
  * Low-level GraphQL access for AniList features that do not yet have a
@@ -18,16 +16,13 @@ export class GraphQLService {
 	 * Executes an arbitrary AniList GraphQL operation.
 	 * @param document - GraphQL query or mutation document.
 	 * @param variables - Optional operation variables.
-	 * @param options - Optional request headers and abort signal.
+	 * @param options - Optional api-core request controls.
 	 * @returns A promise resolving to the typed GraphQL response data.
 	 */
 	request<TData = unknown, TVariables extends object = Record<string, never>>(
 		document: string,
 		variables?: TVariables,
-		options?: Pick<
-			GraphQLClientRequestOptions<TVariables>,
-			"requestHeaders" | "signal"
-		>,
+		options?: AnilistRequestOptions,
 	) {
 		return this.client.request<TData, TVariables>({
 			document,

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import type { RequestContext } from "@api-wrappers/api-core";
-import { createGraphQLClient } from "../src/client";
+import type { GraphQLClientRequestOptions } from "../src/__generated__/anilist-sdk";
+import { createGraphQLClient, type AnilistRequestOptions } from "../src/client";
 
 const requests: RequestContext[] = [];
 
@@ -68,6 +69,34 @@ describe("client transport", () => {
 		expect(requests[0]?.headers["x-request"]).toBe("test");
 		expect(requests[0]?.signal).toBe(signal);
 		expect(body.query.match(/fragment\s+TitleFields\s+on/g)?.length).toBe(1);
+	});
+
+	it("forwards api-core request controls", async () => {
+		const signal = new AbortController().signal;
+		const client = createGraphQLClient({ core: { transport } });
+		const request = client.request as <TData = unknown>(
+			options: GraphQLClientRequestOptions & AnilistRequestOptions,
+		) => Promise<TData>;
+
+		await request({
+			document: "query Viewer { Viewer { id } }",
+			requestHeaders: { "x-request": "test" },
+			signal,
+			timeoutMs: 5_000,
+			cacheKey: "viewer",
+			tags: ["viewer"],
+			operationName: "Viewer",
+		});
+
+		expect(requests[0]).toMatchObject({
+			headers: { "x-request": "test" },
+			signal,
+			timeoutMs: 5_000,
+			cacheKey: "viewer",
+			tags: ["viewer"],
+		});
+		const body = requests[0]?.body as { operationName?: string };
+		expect(body.operationName).toBe("Viewer");
 	});
 
 	it("rejects conflicting fragment definitions before transport", () => {


### PR DESCRIPTION
## What changed

- Adds `AnilistRequestOptions` for raw GraphQL operations.
- Forwards request headers, abort signals, timeout overrides, cache keys, tags, and operation names to api-core.
- Keeps the existing `anilist.graphql.request(document, variables, options)` call shape.
- Exports the request-options type and adds transport-level coverage plus a minor Changeset.

## Why

The low-level GraphQL escape hatch previously exposed only headers and cancellation even though api-core already supports timeouts, caching metadata, operation names, and request tags.

## Validation

GitHub Actions will run formatting, typecheck, tests, and builds on Ubuntu and macOS.