### PR TITLE
docs: expand anime and manga pagination notes

### DIFF
--- a/docs/api/anime.md
+++ b/docs/api/anime.md
@@ -51,7 +51,10 @@ const titles = results.Page?.media
 console.log(titles);
 ```
 
-## Pagination Defaults
+## Pagination
+
+The list methods accept an optional `page` and `perPage`. Leave them off and you
+get the first page, with 10 results for every anime list method.
 
 | Method | `page` default | `perPage` default |
 | --- | --- | --- |
@@ -59,6 +62,21 @@ console.log(titles);
 | `getTrendingAnime` | `1` | `10` |
 | `getPopularAnime` | `1` | `10` |
 | `getAnimeListByGenre` | `1` | `10` |
+
+Pass both values when you want a specific window of results:
+
+```typescript
+// second page, 25 results per page
+const page2 = await anilist.anime.getPopularAnime(2, 25);
+
+for (const media of page2.Page?.media ?? []) {
+	console.log(media?.title?.userPreferred);
+}
+```
+
+AniList can return `null` at any level, including the `Page` itself and the
+entries inside `media`. Use optional chaining, and fall back to an empty array
+before you loop, the way the example does with `?? []`.
 
 ## Related Data
 

--- a/docs/api/manga.md
+++ b/docs/api/manga.md
@@ -47,7 +47,11 @@ for (const media of search.Page?.media ?? []) {
 }
 ```
 
-## Pagination Defaults
+## Pagination
+
+The list methods accept an optional `page` and `perPage`. Leave them off and you
+get the first page. The per-page default is not the same for every call: search
+and genre lookups return 10, while trending and popular return 20.
 
 | Method | `page` default | `perPage` default |
 | --- | --- | --- |
@@ -55,6 +59,21 @@ for (const media of search.Page?.media ?? []) {
 | `getMangaTrending` | `1` | `20` |
 | `getMangaPopular` | `1` | `20` |
 | `getMangaListByGenre` | `1` | `10` |
+
+Pass both values when you want a specific window of results:
+
+```typescript
+// second page, 15 results per page
+const page2 = await anilist.manga.getMangaTrending(2, 15);
+
+for (const media of page2.Page?.media ?? []) {
+	console.log(media?.title?.userPreferred, media?.chapters);
+}
+```
+
+AniList responses are nullable at every level, from the `Page` down to each
+entry in `media`. Guard with optional chaining and default to an empty array
+before looping, as the example does with `?? []`.
 
 ## Genre, Relations, And Credits
 


### PR DESCRIPTION
Closes #28

The anime and manga API docs listed the pagination defaults but didn't show how to page through results or mention that responses can be null. This fills those gaps for the existing list methods, with no new API surface.

- A short note on each page explaining that the list methods take an optional `page` and `perPage`, and what you get when you leave them off.
- Kept the defaults tables, and spelled out that manga `getMangaTrending` and `getMangaPopular` default to 20 per page while the other list methods use 10 (checked against `mangaService.ts` and `animeService.ts`).
- A copyable example on each page that passes an explicit page and perPage.
- A note that AniList responses are nullable at every level, using optional chaining with an `?? []` fallback before looping.

This lines up with two items in `docs/contributing-ideas.md`: adding examples to `docs/api/`, and adding optional-chaining examples for nullable fields.

Written with AI assistance; I've reviewed and tested the change and will maintain it.
